### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "shogi_core"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "shogi_core_c"

--- a/shogi_core/Cargo.toml
+++ b/shogi_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shogi_core"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Rust shogi crates developers"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Changes made in 0.1.1...0.1.2
- Add items for fast array access (https://github.com/rust-shogi-crates/shogi_core/pull/15)
- Add constants (https://github.com/rust-shogi-crates/shogi_core/pull/18, https://github.com/rust-shogi-crates/shogi_core/pull/20)
- Add `Position::moves()` (https://github.com/rust-shogi-crates/shogi_core/pull/24)
- Mark some `Position`-related functions as deprecated (https://github.com/rust-shogi-crates/shogi_core/pull/26)
