### PR TITLE
Faster `Bitboard` operations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,3 +41,15 @@ jobs:
         cargo build --verbose --all-features
     - name: Document
       run: cargo doc --verbose
+    - name: benchmark
+      run: ./bench.sh | tee gha-bench.txt
+    - name: Store benchmark results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Benchmark result (shogi_legality_lite)
+        tool: cargo
+        output-file-path: gha-bench.txt
+        auto-push: false
+    - name: Push benchmark result
+      run: git push 'https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/rust-shogi-crates/shogi_legality_lite.git' gh-pages:gh-pages
+      if: github.event_name != 'pull_request'

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,1 @@
+RUSTFLAGS="--cfg bench" cargo +nightly bench

--- a/include/shogi_core.h
+++ b/include/shogi_core.h
@@ -458,8 +458,9 @@ typedef struct PartialPosition {
   struct Hand hands[2];
   OptionPiece board[81];
   struct Bitboard player_bb[2];
-  struct Bitboard piece_bb[NUM];
+  struct Bitboard piece_bb[14];
   OptionCompactMove last_move;
+  OptionSquare king_square[2];
 } PartialPosition;
 
 /**

--- a/include/shogi_core.h
+++ b/include/shogi_core.h
@@ -458,6 +458,7 @@ typedef struct PartialPosition {
   struct Hand hands[2];
   OptionPiece board[81];
   struct Bitboard player_bb[2];
+  struct Bitboard piece_bb[NUM];
   OptionCompactMove last_move;
 } PartialPosition;
 

--- a/include/shogi_core.h
+++ b/include/shogi_core.h
@@ -759,6 +759,20 @@ OptionPiece PartialPosition_piece_at(const struct PartialPosition *self, Square 
 struct Bitboard PartialPosition_piece_bitboard(const struct PartialPosition *self, Piece piece);
 
 /**
+ * Finds the subset of squares where a [`PieceKind`] is placed.
+ *
+ * Examples:
+ * ```
+ * # use shogi_core::{Bitboard, Color, PartialPosition, PieceKind, Square};
+ * let pos = PartialPosition::startpos();
+ * let rooks = pos.piece_kind_bitboard(PieceKind::Rook);
+ * assert_eq!(rooks, Bitboard::single(Square::SQ_2H) | Bitboard::single(Square::SQ_8B));
+ * ```
+ */
+struct Bitboard PartialPosition_piece_kind_bitboard(const struct PartialPosition *self,
+                                                    PieceKind piece_kind);
+
+/**
  * Finds the subset of squares where a piece of the specified player is placed.
  */
 struct Bitboard PartialPosition_player_bitboard(const struct PartialPosition *self, Color color);

--- a/include/shogi_core.h
+++ b/include/shogi_core.h
@@ -457,6 +457,7 @@ typedef struct PartialPosition {
   uint16_t ply;
   struct Hand hands[2];
   OptionPiece board[81];
+  struct Bitboard player_bb[2];
   OptionCompactMove last_move;
 } PartialPosition;
 
@@ -514,14 +515,7 @@ bool Bitboard_contains(struct Bitboard self, Square square);
 uint8_t Bitboard_count(struct Bitboard self);
 
 /**
- * Creates an empty [`Bitboard`].
- *
- * Examples:
- * ```
- * use shogi_core::Bitboard;
- * let empty = Bitboard::empty();
- * assert_eq!(empty.count(), 0);
- * ```
+ * C interface to [`Bitboard::empty`].
  */
 struct Bitboard Bitboard_empty(void);
 
@@ -565,14 +559,7 @@ struct Bitboard Bitboard_not(struct Bitboard a);
 OptionSquare Bitboard_pop(struct Bitboard *self);
 
 /**
- * Creates a [`Bitboard`] with a single element.
- *
- * Examples:
- * ```
- * use shogi_core::{Bitboard, Square};
- * let sq11 = Bitboard::single(Square::SQ_1A);
- * assert_eq!(sq11.count(), 1);
- * ```
+ * C interface to [`Bitboard::single`].
  */
 struct Bitboard Bitboard_single(Square square);
 

--- a/shogi_core/src/bitboard.rs
+++ b/shogi_core/src/bitboard.rs
@@ -658,6 +658,31 @@ mod tests {
         }
     }
 
+    #[cfg(bench)]
+    #[bench]
+    fn pop_bench(b: &mut test::Bencher) {
+        let init = [
+            b"*.....***",
+            b".......**",
+            b"....*..**",
+            b"*...*...*",
+            b".........",
+            b"*.*.*...*",
+            b"**.......",
+            b"****.....",
+            b"***....**",
+        ];
+        let init = from_strs(init);
+        let count = init.count();
+        b.iter(|| {
+            let mut result = 0;
+            for _square in init {
+                result += 1;
+            }
+            assert_eq!(result, count);
+        });
+    }
+
     #[test]
     fn from_file_works() {
         for file in 1..=9 {
@@ -700,6 +725,37 @@ mod tests {
         }
     }
 
+    #[cfg(bench)]
+    #[bench]
+    fn shift_down_bench(b: &mut test::Bencher) {
+        let init_str = [
+            b"*.....***",
+            b".......**",
+            b"....*..**",
+            b"*...*...*",
+            b".........",
+            b"*.*.*...*",
+            b"**.......",
+            b"****.....",
+            b"***....**",
+        ];
+        let init = from_strs(init_str);
+        let mut expected = vec![];
+        for i in 0..10 {
+            expected.push(unsafe { init.shift_down(i) });
+        }
+        b.iter(|| {
+            let mut x = 0u8;
+            for _ in 0..1000 {
+                x = x.wrapping_mul(13).wrapping_add(9);
+                let result = test::bench::black_box(unsafe {
+                    test::bench::black_box(init).shift_down(x % 10)
+                });
+                assert_eq!(result, expected[(x % 10) as usize]);
+            }
+        });
+    }
+
     #[test]
     fn shift_up_works() {
         let init_str = [
@@ -722,6 +778,37 @@ mod tests {
             let result = unsafe { init.shift_up(i as u8) };
             assert_eq!(result, expected);
         }
+    }
+
+    #[cfg(bench)]
+    #[bench]
+    fn shift_up_bench(b: &mut test::Bencher) {
+        let init_str = [
+            b"*.....***",
+            b".......**",
+            b"....*..**",
+            b"*...*...*",
+            b".........",
+            b"*.*.*...*",
+            b"**.......",
+            b"****.....",
+            b"***....**",
+        ];
+        let init = from_strs(init_str);
+        let mut expected = vec![];
+        for i in 0..10 {
+            expected.push(unsafe { init.shift_up(i) });
+        }
+        b.iter(|| {
+            let mut x = 0u8;
+            for _ in 0..1000 {
+                x = x.wrapping_mul(13).wrapping_add(9);
+                let result = test::bench::black_box(unsafe {
+                    test::bench::black_box(init).shift_up(x % 10)
+                });
+                assert_eq!(result, expected[(x % 10) as usize]);
+            }
+        });
     }
 
     #[test]
@@ -759,6 +846,35 @@ mod tests {
         }
     }
 
+    #[cfg(bench)]
+    #[bench]
+    fn shift_left_bench(b: &mut test::Bencher) {
+        let init = [
+            b"*.....***",
+            b".......**",
+            b"....*..**",
+            b"*...*...*",
+            b".........",
+            b"*.*.*...*",
+            b"**.......",
+            b"****.....",
+            b"***....**",
+        ];
+        let init = from_strs(init);
+        let mut expected = vec![];
+        for i in 0..10 {
+            expected.push(unsafe { init.shift_left(i) });
+        }
+        b.iter(|| {
+            let mut x = 0u8;
+            for _ in 0..1000 {
+                x = x.wrapping_mul(13).wrapping_add(9);
+                let result = unsafe { test::bench::black_box(init).shift_left(x % 10) };
+                assert_eq!(result, expected[(x % 10) as usize]);
+            }
+        });
+    }
+
     #[test]
     fn shift_right_works() {
         let init = [
@@ -792,5 +908,36 @@ mod tests {
             let result = unsafe { init.shift_right(i) };
             assert_eq!(result, result);
         }
+    }
+
+    #[cfg(bench)]
+    #[bench]
+    fn shift_right_bench(b: &mut test::Bencher) {
+        let init = [
+            b"*.....***",
+            b".......**",
+            b"....*..**",
+            b"*...*...*",
+            b".........",
+            b"*.*.*...*",
+            b"**.......",
+            b"****.....",
+            b"***....**",
+        ];
+        let init = from_strs(init);
+        let mut expected = vec![];
+        for i in 0..10 {
+            expected.push(unsafe { init.shift_right(i) });
+        }
+        b.iter(|| {
+            let mut x = 0u8;
+            for _ in 0..1000 {
+                x = x.wrapping_mul(13).wrapping_add(9);
+                let result = test::bench::black_box(unsafe {
+                    test::bench::black_box(init).shift_right(x % 10)
+                });
+                assert_eq!(result, expected[(x % 10) as usize]);
+            }
+        });
     }
 }

--- a/shogi_core/src/bitboard.rs
+++ b/shogi_core/src/bitboard.rs
@@ -24,6 +24,7 @@ impl Bitboard {
     /// assert_eq!(empty.count(), 0);
     /// ```
     /// `const`: since 0.1.3
+    #[inline(always)]
     pub const fn empty() -> Self {
         Self([0; 2])
     }
@@ -69,6 +70,7 @@ impl Bitboard {
     /// assert_eq!((sq11 | sq55).count(), 2);
     /// ```
     #[export_name = "Bitboard_count"]
+    #[inline(always)]
     pub extern "C" fn count(self) -> u8 {
         (self.0[0].count_ones() + self.0[1].count_ones()) as u8
     }
@@ -86,6 +88,7 @@ impl Bitboard {
     /// assert!(Bitboard::empty().is_empty());
     /// ```
     #[export_name = "Bitboard_is_empty"]
+    #[inline(always)]
     pub extern "C" fn is_empty(self) -> bool {
         self.0 == [0; 2]
     }
@@ -361,6 +364,7 @@ macro_rules! define_bit_trait {
         impl $trait for Bitboard {
             type Output = Self;
 
+            #[inline(always)]
             fn $funname(self, rhs: Self) -> Self::Output {
                 Self([self.0[0] $op rhs.0[0], self.0[1] $op rhs.0[1]])
             }
@@ -369,6 +373,7 @@ macro_rules! define_bit_trait {
         impl $trait<&'_ Bitboard> for Bitboard {
             type Output = Bitboard;
 
+            #[inline(always)]
             fn $funname(self, rhs: &Self) -> Self::Output {
                 self $op *rhs
             }
@@ -376,6 +381,7 @@ macro_rules! define_bit_trait {
         impl $trait<Bitboard> for &'_ Bitboard {
             type Output = Bitboard;
 
+            #[inline(always)]
             fn $funname(self, rhs: Bitboard) -> Self::Output {
                 *self $op rhs
             }
@@ -383,26 +389,31 @@ macro_rules! define_bit_trait {
         impl $trait<&'_ Bitboard> for &'_ Bitboard {
             type Output = Bitboard;
 
+            #[inline(always)]
             fn $funname(self, rhs: &Bitboard) -> Self::Output {
                 *self $op *rhs
             }
         }
         impl $assign_trait for Bitboard {
+            #[inline(always)]
             fn $assign_funname(&mut self, rhs: Self) {
                 *self = *self $op rhs;
             }
         }
         impl $assign_trait<&'_ Bitboard> for Bitboard {
+            #[inline(always)]
             fn $assign_funname(&mut self, rhs: &Self) {
                 *self = *self $op *rhs;
             }
         }
         impl $assign_trait<Square> for Bitboard {
+            #[inline(always)]
             fn $assign_funname(&mut self, rhs: Square) {
                 *self = *self $op Bitboard::single(rhs);
             }
         }
         impl $assign_trait<&'_ Square> for Bitboard {
+            #[inline(always)]
             fn $assign_funname(&mut self, rhs: &Square) {
                 *self = *self $op Bitboard::single(*rhs);
             }
@@ -470,6 +481,7 @@ impl Not for Bitboard {
     /// use shogi_core::Bitboard;
     /// assert_eq!((!Bitboard::empty()).count(), 81);
     /// ```
+    #[inline(always)]
     fn not(self) -> Self::Output {
         Self([!self.0[0] & ((1 << 63) - 1), !self.0[1] & ((1 << 18) - 1)])
     }
@@ -487,6 +499,7 @@ impl Not for &'_ Bitboard {
     /// use shogi_core::Bitboard;
     /// assert_eq!((!&Bitboard::empty()).count(), 81);
     /// ```
+    #[inline(always)]
     fn not(self) -> Self::Output {
         !*self
     }
@@ -526,6 +539,9 @@ impl ByteSwappedBitboard {
     ///
     /// # Safety
     /// `a` must be a valid representation of a [`ByteSwappedBitboard`].
+    ///
+    /// Since: 0.1.3
+    #[inline(always)]
     pub const unsafe fn from_u128_unchecked(a: u128) -> Self {
         let v0 = a as u64;
         let v1 = (a >> 64) as u64;
@@ -535,6 +551,7 @@ impl ByteSwappedBitboard {
     /// Bitwise or.
     ///
     /// Since: 0.1.3
+    #[inline(always)]
     pub const fn or(self, other: Self) -> Self {
         Self([self.0[0] | other.0[0], self.0[1] | other.0[1]])
     }
@@ -542,6 +559,7 @@ impl ByteSwappedBitboard {
     /// Bitwise and.
     ///
     /// Since: 0.1.3
+    #[inline(always)]
     pub const fn and(self, other: Self) -> Self {
         Self([self.0[0] & other.0[0], self.0[1] & other.0[1]])
     }
@@ -549,6 +567,7 @@ impl ByteSwappedBitboard {
     /// Bitwise xor.
     ///
     /// Since: 0.1.3
+    #[inline(always)]
     pub const fn xor(self, other: Self) -> Self {
         Self([self.0[0] ^ other.0[0], self.0[1] ^ other.0[1]])
     }
@@ -556,6 +575,7 @@ impl ByteSwappedBitboard {
     /// Bitwise andnot (`!self & others`).
     ///
     /// Since: 0.1.3
+    #[inline(always)]
     pub const fn andnot(self, other: Self) -> Self {
         Self([!self.0[0] & other.0[0], !self.0[1] & other.0[1]])
     }

--- a/shogi_core/src/bitboard.rs
+++ b/shogi_core/src/bitboard.rs
@@ -279,11 +279,12 @@ impl Bitboard {
     /// Since: 0.1.3
     pub const unsafe fn shift_down(self, delta: u8) -> Self {
         debug_assert!(delta <= 9);
-        let top0 = 0x8040_2010_0804_0200u64;
-        let top1 = 0x4_0200u64;
-        let mask0 = top0 - (top0 >> (9 - delta));
-        let mask1 = top1 - (top1 >> (9 - delta));
-        Self([self.0[0] << delta & mask0, self.0[1] << delta & mask1])
+        let top = 0x8040_2010_0804_0200u64;
+        let mask = top - (top >> (9 - delta));
+        Self([
+            self.0[0] << delta & mask,
+            ((self.0[1] as u32) << delta & mask as u32) as u64,
+        ])
     }
 
     /// Shifts a [`Bitboard`] upwards.
@@ -294,11 +295,12 @@ impl Bitboard {
     /// Since: 0.1.3
     pub const unsafe fn shift_up(self, delta: u8) -> Self {
         debug_assert!(delta <= 9);
-        let bottom0 = 0x40_2010_0804_0201u64;
-        let bottom1 = 0x201u64;
-        let mask0 = (bottom0 << (9 - delta)) - bottom0;
-        let mask1 = (bottom1 << (9 - delta)) - bottom1;
-        Self([self.0[0] >> delta & mask0, self.0[1] >> delta & mask1])
+        let bottom = 0x40_2010_0804_0201u64;
+        let mask = (bottom << (9 - delta)) - bottom;
+        Self([
+            self.0[0] >> delta & mask,
+            (self.0[1] as u32 >> delta & mask as u32) as u64,
+        ])
     }
 
     /// Shifts a [`Bitboard`] left.

--- a/shogi_core/src/lib.rs
+++ b/shogi_core/src/lib.rs
@@ -1,6 +1,10 @@
 #![cfg_attr(not(test), no_std)] // Forbids using std::*.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(bench, feature(test))]
 #![doc = include_str!("../README.md")]
+
+#[cfg(bench)]
+extern crate test;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/shogi_core/src/lib.rs
+++ b/shogi_core/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::mv::CompactMove;
 pub use crate::hand::Hand;
 
 #[doc(inline)]
-pub use crate::bitboard::Bitboard;
+pub use crate::bitboard::{Bitboard, ByteSwappedBitboard};
 
 #[doc(inline)]
 pub use crate::game_resolution::GameResolution;

--- a/shogi_core/src/position.rs
+++ b/shogi_core/src/position.rs
@@ -548,12 +548,14 @@ impl PartialPosition {
     /// let vacant = pos.piece_at(Square::SQ_3H);
     /// assert_eq!(vacant, None);
     /// ```
+    #[inline(always)]
     pub fn piece_at(&self, square: Square) -> Option<Piece> {
         self.PartialPosition_piece_at(square).into()
     }
 
     /// C interface to [`PartialPosition::piece_at`].
     #[no_mangle]
+    #[inline(always)]
     pub extern "C" fn PartialPosition_piece_at(&self, square: Square) -> OptionPiece {
         let index = square.index() - 1;
         // Safety: square.index() is in range 1..=81
@@ -595,6 +597,7 @@ impl PartialPosition {
 
     /// Finds the subset of squares with no pieces.
     #[export_name = "PartialPosition_vacant_bitboard"]
+    #[inline(always)]
     pub extern "C" fn vacant_bitboard(&self) -> Bitboard {
         !(self.player_bb[0] | self.player_bb[1])
     }
@@ -618,6 +621,7 @@ impl PartialPosition {
     /// assert_eq!(white_rook, Bitboard::single(Square::SQ_8B));
     /// ```
     #[export_name = "PartialPosition_piece_bitboard"]
+    #[inline(always)]
     pub extern "C" fn piece_bitboard(&self, piece: Piece) -> Bitboard {
         let (piece_kind, color) = piece.to_parts();
         self.piece_bb[piece_kind.array_index()] & self.player_bb[color.array_index()]

--- a/shogi_core/src/position.rs
+++ b/shogi_core/src/position.rs
@@ -391,7 +391,7 @@ impl PartialPosition {
         let mut i = 0;
         while i < 9 {
             // Safety: i+1 is in range 1..=9.
-            let file = unsafe { Bitboard::from_file(i as u8 + 1, 1 << 8 | 1 << 6) };
+            let file = unsafe { Bitboard::from_file_unchecked(i as u8 + 1, 1 << 8 | 1 << 6) };
             result = result.or(file);
             i += 1;
         }
@@ -405,7 +405,7 @@ impl PartialPosition {
         let mut i = 0;
         while i < 9 {
             // Safety: i+1 is in range 1..=9.
-            let file = unsafe { Bitboard::from_file(i as u8 + 1, 1 << 2 | 1) };
+            let file = unsafe { Bitboard::from_file_unchecked(i as u8 + 1, 1 << 2 | 1) };
             result = result.or(file);
             i += 1;
         }

--- a/shogi_core/src/position.rs
+++ b/shogi_core/src/position.rs
@@ -601,11 +601,9 @@ impl PartialPosition {
 
     /// Finds the subset of squares where a piece of the specified player is placed.
     #[export_name = "PartialPosition_player_bitboard"]
+    #[inline(always)]
     pub extern "C" fn player_bitboard(&self, color: Color) -> Bitboard {
-        match color {
-            Color::Black => self.player_bb[0],
-            Color::White => self.player_bb[1],
-        }
+        self.player_bb[color.array_index()]
     }
 
     /// Finds the subset of squares where a piece is placed.
@@ -623,6 +621,21 @@ impl PartialPosition {
     pub extern "C" fn piece_bitboard(&self, piece: Piece) -> Bitboard {
         let (piece_kind, color) = piece.to_parts();
         self.piece_bb[piece_kind.array_index()] & self.player_bb[color.array_index()]
+    }
+
+    /// Finds the subset of squares where a [`PieceKind`] is placed.
+    ///
+    /// Examples:
+    /// ```
+    /// # use shogi_core::{Bitboard, Color, PartialPosition, PieceKind, Square};
+    /// let pos = PartialPosition::startpos();
+    /// let rooks = pos.piece_kind_bitboard(PieceKind::Rook);
+    /// assert_eq!(rooks, Bitboard::single(Square::SQ_2H) | Bitboard::single(Square::SQ_8B));
+    /// ```
+    #[export_name = "PartialPosition_piece_kind_bitboard"]
+    #[inline(always)]
+    pub extern "C" fn piece_kind_bitboard(&self, piece_kind: PieceKind) -> Bitboard {
+        self.piece_bb[piece_kind.array_index()]
     }
 
     /// Returns the last move, if it exists.

--- a/shogi_core/src/square.rs
+++ b/shogi_core/src/square.rs
@@ -15,6 +15,7 @@ impl Square {
     ///
     /// `file` and `rank` must be between 1 and 9 (both inclusive).
     /// If this condition is not met, this function returns None.
+    #[inline(always)]
     pub const fn new(file: u8, rank: u8) -> Option<Self> {
         if file.wrapping_sub(1) >= 9 || rank.wrapping_sub(1) >= 9 {
             return None;
@@ -69,6 +70,7 @@ impl Square {
     /// use shogi_core::Square;
     /// assert_eq!(Square::SQ_3D.file(), 3);
     /// ```
+    #[inline(always)]
     #[export_name = "Square_file"]
     pub extern "C" fn file(self) -> u8 {
         (self.0.get() + 8) / 9
@@ -81,6 +83,7 @@ impl Square {
     /// use shogi_core::Square;
     /// assert_eq!(Square::SQ_3D.rank(), 4);
     /// ```
+    #[inline(always)]
     #[export_name = "Square_rank"]
     pub extern "C" fn rank(self) -> u8 {
         ((self.0.get() - 1) % 9) + 1
@@ -128,6 +131,7 @@ impl Square {
     /// assert_eq!(Square::SQ_1A.flip(), Square::SQ_9I);
     /// assert_eq!(Square::SQ_3D.flip(), Square::SQ_7F);
     /// ```
+    #[inline(always)]
     #[export_name = "Square_flip"]
     pub extern "C" fn flip(self) -> Self {
         // Safety: self.0.get() is in range 1..=81.
@@ -200,7 +204,7 @@ impl Square {
     /// Returns the index of `self` for array accesses. This function returns an integer in range `0..Square::MAX`.
     ///
     /// Since: 0.1.2
-    #[inline]
+    #[inline(always)]
     pub const fn array_index(self) -> usize {
         (self.0.get() - 1) as usize
     }


### PR DESCRIPTION
## Notes
Using tables for `Bitboard::shift_{up,down}` ([u128; 9]) was not faster.

## TODO
- [x] docs
