### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "shogi_core"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "shogi_core_c"

--- a/shogi_core/Cargo.toml
+++ b/shogi_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shogi_core"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Rust shogi crates developers"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Milestone: https://github.com/rust-shogi-crates/shogi_core/milestone/4?closed=1

Changes:
- `Bitboard`-related functions made fast ([#29](https://github.com/rust-shogi-crates/shogi_core/pull/29), [#30](https://github.com/rust-shogi-crates/shogi_core/pull/30), [#31](https://github.com/rust-shogi-crates/shogi_core/pull/31), [#32](https://github.com/rust-shogi-crates/shogi_core/pull/32))
